### PR TITLE
Fixing preferences-service.jar symlink to point to correct jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,8 +165,8 @@ ospackage {
     }
 
     // check to see which jar got built for our symlink so the init script works
-    def version_jar = app_name + '-' + version_clean + '.jar'
-    def snapshot_jar = app_name + '-' + version_snapshot + '.jar'
+    def version_jar = package_name + '-' + version_clean + '.jar'
+    def snapshot_jar = package_name + '-' + version_snapshot + '.jar'
     def built_jar
     if (file('build/libs/' + version_jar).exists()) {
         built_jar = version_jar


### PR DESCRIPTION
Currently the preferences-service.jar is point to preferences-service-VERSION.jar when it needs to be point to cloudfeeds-preferences-svc-VERSION.jar.  