### PR TITLE
Limit flyway to only apply schema for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ dependencies {
         transitive = false
     }
     compile 'org.flywaydb:flyway-core:3.1'
-    compile 'com.rackspace.prefs:cloudfeeds-preferences-svc-db:1.1.0'
+    compile 'com.rackspace.prefs:cloudfeeds-preferences-svc-db:1.1.3'
     compile 'org.postgresql:postgresql:9.3-1102-jdbc41'
     testCompile 'org.scalatest:scalatest_2.10:2.1.7'
     testCompile 'org.scalatra:scalatra-scalatest_2.10:2.3.0'
@@ -227,7 +227,7 @@ flyway {
     url  = "jdbc:h2:file:${buildDir}/db/test/preferencesdb;MODE=PostgreSQL;IGNORECASE=TRUE"
     user = 'root'
     locations = [
-            'classpath:sql'
+            'classpath:sql/schema'
     ]
 }
 


### PR DESCRIPTION
Because H2 doesn't like postgresql grant syntax,  update the flyway options to only apply the schema files from the cloudfeeds-preferences-svc-db package. 