### PR TITLE
[cf-340] Remove slick dynamic sessions and use regular sessions

### DIFF
--- a/src/main/scala/com/rackspace/prefs/PreferencesService.scala
+++ b/src/main/scala/com/rackspace/prefs/PreferencesService.scala
@@ -12,7 +12,6 @@ import org.scalatra.scalate.ScalateSupport
 import collection.JavaConverters._
 import scala.slick.driver.JdbcDriver.simple._
 import scala.slick.jdbc.JdbcBackend.Database
-import scala.slick.jdbc.JdbcBackend.Database.dynamicSession
 import javax.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
 
@@ -46,7 +45,7 @@ with JacksonJsonSupport {
         val id = uriParts(1)
         contentType = formats("json")
 
-        db withDynSession {
+        db.withSession { implicit session =>
 
             val getPayloadQuery = for {
                 (prefs, metadata) <- preferences innerJoin preferencesMetadata on (_.preferencesMetadataId === _.id)
@@ -78,7 +77,7 @@ with JacksonJsonSupport {
 
                     case Nil => {
 
-                        db withDynSession {
+                        db.withSession { implicit session =>
                             val prefsForIdandSlug = preferences.filter(prefs => prefs.id === id && prefs.preferencesMetadataId === metadata.id)
 
                             prefsForIdandSlug.list match {
@@ -109,7 +108,7 @@ with JacksonJsonSupport {
     }
 
     def getMetadata(slug: String): Option[PreferencesMetadata] = {
-        db withDynSession {
+        db.withSession { implicit session =>
             preferencesMetadata.filter(_.slug === slug).list match {
                 case List(metadata: PreferencesMetadata) => Some(metadata)
                 case _ => None

--- a/src/test/scala/com/rackspace/prefs/model/DBTablesIT.scala
+++ b/src/test/scala/com/rackspace/prefs/model/DBTablesIT.scala
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory
 
 import scala.slick.driver.JdbcDriver.simple._
 import scala.slick.jdbc.JdbcBackend.Database
-import scala.slick.jdbc.JdbcBackend.Database.dynamicSession
 
 
 class DBTablesIT extends FunSuite with BeforeAndAfterAll with InitDbTrait {
@@ -24,7 +23,7 @@ class DBTablesIT extends FunSuite with BeforeAndAfterAll with InitDbTrait {
     val tenantId = "tenant_1"
     val currentTime = new DateTime()
 
-    db withDynSession {
+    db.withSession { implicit session =>
       val archivePrefsMetadataId =
         preferencesMetadata.filter(_.slug === ArchivePrefsMetadataSlug).map(_.id).run.head
 
@@ -32,7 +31,7 @@ class DBTablesIT extends FunSuite with BeforeAndAfterAll with InitDbTrait {
           .insert(tenantId, archivePrefsMetadataId, "{\"payload\": \"JSON blob\"}")
     }
 
-    val hasTenantPreference = db withDynSession {
+    val hasTenantPreference = db.withSession { implicit session =>
       preferences.filter(_.id === tenantId).run.nonEmpty
     }
 
@@ -46,7 +45,7 @@ class DBTablesIT extends FunSuite with BeforeAndAfterAll with InitDbTrait {
     val currentTime = new DateTime()
 
     try {
-      db withDynSession {
+      db.withSession { implicit session =>
         val archivePrefsMetadataId =
           preferencesMetadata.filter(_.slug === ArchivePrefsMetadataSlug).map(_.id).run.head
 

--- a/src/test/scala/com/rackspace/prefs/model/InitDbTrait.scala
+++ b/src/test/scala/com/rackspace/prefs/model/InitDbTrait.scala
@@ -4,7 +4,6 @@ import com.rackspace.prefs.model.DBTables._
 
 import scala.slick.driver.JdbcDriver.simple._
 import scala.slick.jdbc.JdbcBackend.Database
-import scala.slick.jdbc.JdbcBackend.Database.dynamicSession
 import org.joda.time.DateTime
 
 trait InitDbTrait {
@@ -13,7 +12,7 @@ trait InitDbTrait {
 
     def createPreference(db: Database, id: String, preferenceSlug: String, payload: String) {
         val currentTime = new DateTime()
-        db withDynSession {
+        db.withSession { implicit session =>
           val prefsMetadataId =
             preferencesMetadata.filter(_.slug === preferenceSlug).map(_.id).run.head
 
@@ -24,7 +23,7 @@ trait InitDbTrait {
     }
 
     def clearData(db: Database) {
-      db withDynSession {
+      db.withSession { implicit session =>
         preferences.delete
       }
     }


### PR DESCRIPTION
withDynSession uses thread local session. The big issue with threadLocalSession is that you can have runtime failures whenever something uses it outside of a withDynSession block. To avoid this risk, its better to use withSession either by passing session around or with implicit sessions.