### PR TITLE
hardcode symlink to the non-snapshot version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,17 +179,11 @@ ospackage {
 
     // check to see which jar got built for our symlink so the init script works
     def version_jar = package_name + '-' + version_clean + '.jar'
-    def snapshot_jar = package_name + '-' + version_snapshot + '.jar'
-    def built_jar
-    if (file('build/libs/' + version_jar).exists()) {
-        built_jar = version_jar
-    } else {
-        built_jar = snapshot_jar
-    }
-    // println built_jar
+    // println version_jar
 
     // create a symlink to named <app_name>.jar to the versioned jar
-    link(prefix_path + '/lib/' + app_name + '.jar', prefix_path + '/lib/' + built_jar)
+    // FIXME: It should be noted that this won't work with -SNAPSHOT versions
+    link(prefix_path + '/lib/' + app_name + '.jar', prefix_path + '/lib/' + version_jar)
 
 }
 


### PR DESCRIPTION
Since we generally only run the rpm version in environments that should have a full version and not a snapshot version, assume we want to symlink the non-snapshot version of the jar.  In theory the DAEMON_JAR can be overridden in /etc/sysconfig/preferences-service to support developers wanting to run a custom version.