### PR TITLE
CF-423: fix release plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,8 @@ apply plugin: 'application'
 apply plugin: 'os-package-base'
 apply plugin: 'flyway'
 
+archivesBaseName = custom.parentProject + '-' + project.name
+
 sourceCompatibility = '1.7'
 mainClassName = "com.rackspace.prefs.WebApp"
 
@@ -72,7 +74,7 @@ dependencies {
 
 // task to create one uber executable jar
 task uberjar(type: Jar) {
-    baseName = 'cloudfeeds-preferences-svc-app'
+    baseName = custom.parentProject + '-' + project.name
     from {
         sourceSets.main.output
     } {
@@ -149,6 +151,8 @@ ospackage {
 task buildRpm(type: Rpm, dependsOn: 'uberjar') {
     // this task inherits defaults from the ospackage section
 
+    baseName = custom.parentProject + '-' + project.name
+
     // the init script uses daemonize, require it
     requires('daemonize')
 
@@ -158,7 +162,7 @@ task buildRpm(type: Rpm, dependsOn: 'uberjar') {
 
 artifacts {
     archives(buildRpm) {
-        name   app_name
+        name   custom.parentProject + '-' + project.name
         type   'rpm'
         builtBy buildRpm
     }
@@ -168,8 +172,9 @@ uploadArchives {
     repositories {
         mavenDeployer {
             pom.groupId    = custom.group
-            pom.artifactId = project.parent.name + '-' + project.name
+            pom.artifactId = custom.parentProject + '-' + project.name
             pom.version    = project.version
+            println("app: artifactId=" + pom.artifactId)
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,15 @@ task writeNewPom << {
 }
 
 task test {
-  dependsOn task(':db:test'), task(':app:test')
+    dependsOn task(':db:test'), task(':app:test')
+}
+
+artifacts {
+    def app_artifact = custom.parentProject + '-app-' + project.version.minus('-SNAPSHOT') + '-1.noarch.rpm'
+    archives file: file('app/build/distributions/' + app_artifact), name: app_artifact, type: 'rpm', classifier: 'app'
+
+    def db_artifact = custom.parentProject + '-db-' + project.version.minus('-SNAPSHOT') + '.zip'
+    archives file: file('db/build/distributions/' + db_artifact), name: db_artifact, type: 'zip', classifier: 'db'
 }
 
 uploadArchives {
@@ -77,7 +85,7 @@ uploadArchives {
         mavenDeployer {
             pom.groupId    = project.group
             pom.artifactId = project.name
-            pom.version    = project.version
+            pom.version    = project.version.minus('-SNAPSHOT')
             //println('main: groupId=' + pom.groupId)
             //println('main: artifactId=' + pom.artifactId)
             //println('main: version=' + pom.version)

--- a/common.gradle
+++ b/common.gradle
@@ -1,3 +1,4 @@
 ext.custom = [
-  group:          'com.rackspace.prefs.cloudfeeds'
+  group:          'com.rackspace.prefs.cloudfeeds',
+  parentProject:  'cloudfeeds-preferences-svc'
 ]

--- a/db/build.gradle
+++ b/db/build.gradle
@@ -12,6 +12,8 @@ buildscript {
 
 apply plugin: 'java'
 
+archivesBaseName = custom.parentProject + '-' + project.name
+
 dependencies {
     compile('org.flywaydb:flyway-commandline:3.1') {
         transitive = false
@@ -22,9 +24,9 @@ dependencies {
 }
 
 task buildZip(type: Zip) {
-
     from sourceSets.main.output
 
+    baseName = custom.parentProject + '-' + project.name
     into('lib') {
         from configurations.runtime
     }
@@ -42,8 +44,9 @@ uploadArchives {
     repositories {
         mavenDeployer {
             pom.groupId    = custom.group
-            pom.artifactId = project.parent.name + '-' + project.name
+            pom.artifactId = custom.parentProject + '-' + project.name
             pom.version    = project.version
+            println("db: artifactId=" + pom.artifactId)
         }
     }
 }


### PR DESCRIPTION
This PR fixes the issue with using Gradle Release plugin. According to the Release plugin GitHub page, the plugin does not work well with multi-projects build. It recommends that only the parent/root project is configured to use the Release plugin and not the child/sub-projects. 

When the Release plugin is invoked from the parents, the side effect is that the artifacts are uploaded as the parent's artifacts (i.e: artifactId is set to cloudfeeds-preferences-svc, instead of cloudfeeds-preferences-svc-app or cloudfeeds-preferences-svc-db). Therefore in Nexus, it will go under:

https://maven.research.rackspacecloud.com/content/repositories/releases/com/rackspace/prefs/cloudfeeds/cloudfeeds-preferences-svc/

And undernearth that, there will be:
```
1.1.0/cloudfeeds-preferences-svc-1.1.0-1.noarch.rpm
1.1.0/cloudfeeds-preferences-svc-1.1.0.zip
```
The first one is the output of the app subproject, and the second one is the output of the db subproject. I added a Maven classifier so at least they will look like this:
```
1.1.0/cloudfeeds-preferences-svc-1.1.0-app-1.noarch.rpm
1.1.0/cloudfeeds-preferences-svc-1.1.0-db.zip
```
This is less than ideal. 

But it's the lesser evil. I also tried invoking the Release plugin individually from the subprojects. The side effect of that is the code base was tagged twice and there were 2 * n commits where n is the number of subprojects.
