### PR TITLE
CF-601 inconsistent error code with trailing slash

### DIFF
--- a/app/src/main/scala/com/rackspace/prefs/PreferencesService.scala
+++ b/app/src/main/scala/com/rackspace/prefs/PreferencesService.scala
@@ -36,9 +36,8 @@ with JacksonJsonSupport {
         }
     }
 
-    get("""^/metadata/([^/?]+)/?""".r) {
-        val uriParts = multiParams("captures")
-        val preferenceSlug = uriParts(0)
+    get("/metadata/:preference_slug/?") {
+        val preferenceSlug = params("preference_slug")
         contentType = formats("json")
         getMetadata(preferenceSlug) match {
             case Some(metadata: PreferencesMetadata) => metadata.schema
@@ -47,7 +46,7 @@ with JacksonJsonSupport {
     }
 
     // anything that's not /metadata* goes here
-    get( """^/(?!metadata)([^/?]*)/([^/?]*)""".r) {
+    get( """^/(?!metadata)([^/]*)/([^/]*)/?$""".r) {
         val uriParts = multiParams("captures")
         val preferenceSlug = uriParts(0)
         val id = uriParts(1)
@@ -67,10 +66,9 @@ with JacksonJsonSupport {
         }
     }
 
-    post( """^/([^/?]*)/([^/?]*)""".r, request.getContentType() == "application/json" ) {
-        val uriParts = multiParams("captures")
-        val preferenceSlug = uriParts(0)
-        val id = uriParts(1)
+    post("/:preference_slug/:id/?", request.getContentType() == "application/json") {
+        val preferenceSlug = params("preference_slug")
+        val id = params("id")
         val payload = request.body
 
         getMetadata(preferenceSlug) match {

--- a/app/src/test/scala/com/rackspace/prefs/FeedsArchivePreferencesTest.scala
+++ b/app/src/test/scala/com/rackspace/prefs/FeedsArchivePreferencesTest.scala
@@ -132,6 +132,16 @@ class FeedsArchivePreferencesTest extends ScalatraSuite with FunSuiteLike with I
         }
     }
 
+    test("should get 404: GET on preferences with extra resource in path /archive/:id/extra/stuff") {
+        val randomId = Random.nextInt()
+        createPreference(db, randomId.toString(), "archive", prefs_enable_all)
+
+        info("Calling GET /archive/" + randomId + "/extra/stuff")
+        get("/archive/" + randomId + "/extra/stuff") {
+          status should equal (404)
+        }
+    }
+
     test("should get 201: POST of a new good preferences to /archive/:id") {
         val randomId = Random.nextInt()
         info("Calling POST /archive/" + randomId)


### PR DESCRIPTION
- simplified route path to not use regex unless have to
- add rule and test case to disallow extra slugs after /preference/id/