### PR TITLE
Add rollback script for schema V1.3

### DIFF
--- a/db/src/main/resources/sql/rollback/RB1.3__data_feeds_archives_update_dc_optional.sql
+++ b/db/src/main/resources/sql/rollback/RB1.3__data_feeds_archives_update_dc_optional.sql
@@ -1,0 +1,26 @@
+-- revert record slug='archive' in table preferences_metadata to previous schema version 1.2
+begin;
+
+update "preferences_metadata"
+set "schema" = 'object {
+            boolean enabled;
+            array [
+              string [ "JSON", "XML" ];
+            ] {1,2} data_format;
+            string  default_archive_container_url?;
+            object {
+              string iad;
+              string ord;
+              string dfw;
+              string lon;
+              string hkg;
+              string syd;
+            } archive_container_urls?;
+        };'
+where "slug" = 'archive';
+
+-- remove the flyway version 1.3
+delete from "schema_version"
+where "version" = '1.3';
+
+end;


### PR DESCRIPTION
We won't be able to revert to previous schema version via flyway for our database changes.

After discussing the process with the Customer Service team (Srikanth and Ranjith), we think the best solution for rolling back changes is to create the rollback script that can be executed manually to change the database back to the previous version, and to remove the latest version from the flyway "schema_version" table.

I have created a rollback directory in the db/src/main/resources/sql/ directory, and created the rollback script with SQL to "revert" the changes, the file name preface with "RB".  This way, the rollback scripts will be bundled with the flyway zipped package for deployment, but flyway will not execute these files because by default it only looks for files preface with "V" in the "schema" directory.

We should from now on always create a rollback script that will undo the changes for the new schema version that flyway will execute when deploy, and delete that version from the "schema_version" table.
The rollback script should always be placed in the rollback directory with the naming convention "RBXYZ", where XYZ is the schema version it is rolling back from.

When creating the NEB and CCM, we will have to include instruction for the Ops to locate and execute the rollback script manually against the master database.

@ChandraAddala @shintasmith @usnavi 
What do you guys think of this process.  See the added rollback script RB1.3__data_feeds_archives_update_dc_optional.sql for further details (see comments).
