### PR TITLE
CF-1177: check for prefs not having archive_urls at all

### DIFF
--- a/app/src/main/scala/com/rackspace/prefs/PreferencesService.scala
+++ b/app/src/main/scala/com/rackspace/prefs/PreferencesService.scala
@@ -369,8 +369,13 @@ with JacksonJsonSupport {
      */
     def allDataCenterArePresent(preferenceSlug: String, id: String, preferenceJson: JValue): Boolean = {
         // extract "archive_container_urls": { datacenter: url } to Map(String, Any)
-        val containerUrls = (preferenceJson \ "archive_container_urls").extract[Map[String, Any]]
+        val containerUrlsObj = (preferenceJson \ "archive_container_urls")
+        if ( containerUrlsObj == JNothing ) {
+            return false
+        }
+
         // check for all data centers and return boolean
+        val containerUrls = containerUrlsObj.extract[Map[String, Any]]
         containerUrls.contains("iad") &&
         containerUrls.contains("dfw") &&
         containerUrls.contains("ord") &&

--- a/app/src/test/scala/com/rackspace/prefs/FeedsArchivePreferencesTest.scala
+++ b/app/src/test/scala/com/rackspace/prefs/FeedsArchivePreferencesTest.scala
@@ -903,6 +903,25 @@ class FeedsArchivePreferencesTest extends ScalatraSuite with FunSuiteLike with I
         }
     }
 
+    test("should get 400: POST of invalid preferences with NO default and NO data center") {
+        val randomId = Random.nextInt()
+        info("Calling POST /archive/" + randomId + "/")
+        post("/archive/" + randomId + "/",
+            f"""
+              |{
+              |  "enabled" : true,
+              |  "data_format" : [ "XML" ]
+              |}
+            """.stripMargin
+            , Map("Content-Type" -> "application/json", "x-tenant-id" -> "Nast-Id_1")) {
+            if ( status != 400 ) {
+                info(body)
+            }
+            status should equal (400)
+            body should include ("Preferences for /archive/" + randomId + " must have a default_container_url or must have all datacenter archive_container_urls present")
+        }
+    }
+
     test("should get 201: POST of good preferences with NO default and ALL data center") {
       val randomId = Random.nextInt()
       info("Calling POST /archive/" + randomId + "/")


### PR DESCRIPTION
Add a check if there's no archive_urls at all, return false immediately, before trying to extract the data to a Map.